### PR TITLE
Support for SLD 1.0.0, no filtered rules and Style by layer name

### DIFF
--- a/leaflet.sld.js
+++ b/leaflet.sld.js
@@ -51,17 +51,26 @@ var comparisionOperatorMapping = {
 // namespaces for Tag lookup in XML
 var namespaceMapping = {
    se: 'http://www.opengis.net/se',
-   ogc: 'http://www.opengis.net/ogc'
+   ogc: 'http://www.opengis.net/ogc',
+   sld: 'http://www.opengis.net/sld'
 };
 
 function getTagNameArray(element, tagName) {
    var tagParts = tagName.split(':');
    var ns = null;
+   var tags;
+
    if (tagParts.length == 2) {
       ns = tagParts[0];
       tagName = tagParts[1];
    }
-   return [].slice.call(element.getElementsByTagNameNS(namespaceMapping[ns], tagName));
+
+   tags = [].slice.call(element.getElementsByTagNameNS(namespaceMapping[ns], tagName));
+
+   if(!tags.length && ns === 'se')
+      return getTagNameArray(element, 'sld:' + tagName);
+   else
+      return tags;
 };
 
 /**
@@ -85,6 +94,10 @@ L.SLDStyler = L.Class.extend({
       // are unique so don't bother parsing them seperatly.
       var parameters = getTagNameArray(symbolizer, 'se:SvgParameter');
       var cssParams = L.extend({}, defaultStyle);
+
+      if(!parameters.length)
+         parameters = getTagNameArray(symbolizer, 'se:CssParameter');
+
       parameters.forEach(function(param) {
          var key = param.getAttribute('name');
          var mappedKey = attributeNameMapping[key];

--- a/leaflet.sld.js
+++ b/leaflet.sld.js
@@ -116,27 +116,28 @@ L.SLDStyler = L.Class.extend({
       return cssParams;
    },
    parseFilter: function(filter) {
-
-      var hasAnd = getTagNameArray(filter, 'ogc:And').length;
-      var hasOr = getTagNameArray(filter, 'ogc:Or').length;
-      var filterJson = {
-         operator: hasAnd == true ? 'and' : hasOr ?  'or' : null,
-         comparisions: []
-      };
-      Object.keys(comparisionOperatorMapping).forEach(function(key) {
-         var comparisionElements = getTagNameArray(filter, key);
-         var comparisionOperator = comparisionOperatorMapping[key];
-         comparisionElements.forEach(function(comparisionElement) {
-            var property = getTagNameArray(comparisionElement, 'ogc:PropertyName')[0].textContent;
-            var literal = getTagNameArray(comparisionElement, 'ogc:Literal')[0].textContent;
-            filterJson.comparisions.push({
-               operator: comparisionOperator,
-               property: property,
-               literal: literal
+      if(filter) {
+         var hasAnd = getTagNameArray(filter, 'ogc:And').length;
+         var hasOr = getTagNameArray(filter, 'ogc:Or').length;
+         var filterJson = {
+            operator: hasAnd == true ? 'and' : hasOr ?  'or' : null,
+            comparisions: []
+         };
+         Object.keys(comparisionOperatorMapping).forEach(function(key) {
+            var comparisionElements = getTagNameArray(filter, key);
+            var comparisionOperator = comparisionOperatorMapping[key];
+            comparisionElements.forEach(function(comparisionElement) {
+               var property = getTagNameArray(comparisionElement, 'ogc:PropertyName')[0].textContent;
+               var literal = getTagNameArray(comparisionElement, 'ogc:Literal')[0].textContent;
+               filterJson.comparisions.push({
+                  operator: comparisionOperator,
+                  property: property,
+                  literal: literal
+               })
             })
-         })
-      });
-      return filterJson;
+         });
+         return filterJson;
+      }
    },
    parseRule: function(rule) {
 
@@ -163,24 +164,27 @@ L.SLDStyler = L.Class.extend({
       }, this);
    },
    isFilterMatch: function(filter, properties) {
-      var operator = filter.operator == null || filter.operator == 'and' ? 'every' : 'some';
-      return filter.comparisions[operator](function(comp) {
-         if (comp.operator == '==') {
-            return properties[comp.property] == comp.literal;
-         } else if (comp.operator == '!=') {
-            return properties[comp.property] == comp.literal;
-         } else if (comp.operator == '<') {
-            return properties[comp.property] < comp.literal;
-         } else if (comp.operator == '>') {
-            return properties[comp.property] > comp.literal;
-         } else if (comp.operator == '<=') {
-            return properties[comp.property] <= comp.literal;
-         } else if (comp.operator == '>=') {
-            return properties[comp.property] >= comp.literal;
-         } else {
-            console.error('Unknown comparision operator', comp.operator);
-         }
-      });
+      if (filter) {
+         var operator = filter.operator == null || filter.operator == 'and' ? 'every' : 'some';
+         return filter.comparisions[operator](function(comp) {
+            if (comp.operator == '==') {
+               return properties[comp.property] == comp.literal;
+            } else if (comp.operator == '!=') {
+               return properties[comp.property] == comp.literal;
+            } else if (comp.operator == '<') {
+               return properties[comp.property] < comp.literal;
+            } else if (comp.operator == '>') {
+               return properties[comp.property] > comp.literal;
+            } else if (comp.operator == '<=') {
+               return properties[comp.property] <= comp.literal;
+            } else if (comp.operator == '>=') {
+               return properties[comp.property] >= comp.literal;
+            } else {
+               console.error('Unknown comparision operator', comp.operator);
+            }
+         });
+      } else
+         return true;
    },
    styleFn: function(feature) {
       var matchingRule = null;


### PR DESCRIPTION
I have added the following features:

- Support for SLD version 1.0.0.
- Support for non filtered rules, it sends an error when try to use it.
- Use layer name in `getStyleFunction` using `getStyleFunction('name of layer')`.