### PR TITLE
Add support for points without stroke line

### DIFF
--- a/leaflet.sld.js
+++ b/leaflet.sld.js
@@ -108,10 +108,9 @@ L.SLDStyler = L.Class.extend({
 
    // translates PolygonSymbolizer attributes into Path attributes
    parseSymbolizer: function(symbolizer) {
-
       // SvgParameter names below se:Fill and se:Stroke
       // are unique so don't bother parsing them seperatly.
-      var parameters = getTagNameArray(symbolizer, 'se:SvgParameter');         
+      var parameters = getTagNameArray(symbolizer, 'se:SvgParameter');
       var cssParams = L.extend({}, defaultStyle);
 
       if(!parameters.length) {

--- a/leaflet.sld.js
+++ b/leaflet.sld.js
@@ -108,11 +108,11 @@ L.SLDStyler = L.Class.extend({
 
    // translates PolygonSymbolizer attributes into Path attributes
    parseSymbolizer: function(symbolizer) {
-      var cssParams = L.extend({}, defaultStyle);
 
       // SvgParameter names below se:Fill and se:Stroke
       // are unique so don't bother parsing them seperatly.
       var parameters = getTagNameArray(symbolizer, 'se:SvgParameter');         
+      var cssParams = L.extend({}, defaultStyle);
 
       if(!parameters.length) {
          parameters = getTagNameArray(symbolizer, 'se:CssParameter');

--- a/leaflet.sld.legend.js
+++ b/leaflet.sld.legend.js
@@ -79,11 +79,19 @@ export default class LeafletSldLegend {
             const sizeNode = pointSymbolizerNode.querySelector('Size');
 
             // Get fill color
-            const fillColor = fillNode ? fillNode.querySelector('SvgParameter[name="fill"]').textContent : 'none';
-
+            let fillColorAttribute = "";
+            if (fillNode && fillNode.children.length) {
+                const fillColor = fillNode.querySelector('SvgParameter[name="fill"]').textContent;
+                fillColorAttribute = `fill="${fillColor}"`
+            }
+            
             // Get stroke color and width
-            const strokeColor = strokeNode ? strokeNode.querySelector('SvgParameter[name="stroke"]').textContent : 'none';
-            const strokeWidth = strokeNode ? strokeNode.querySelector('SvgParameter[name="stroke-width"]').textContent : '0';
+            let strokeAttributes = "";
+            if (strokeNode && strokeNode.children.length) {
+                const strokeColor = strokeNode ? strokeNode.querySelector('SvgParameter[name="stroke"]').textContent : 'none';
+                const strokeWidth = strokeNode ? strokeNode.querySelector('SvgParameter[name="stroke-width"]').textContent : '0';
+                strokeAttributes = `stroke="${strokeColor}" stroke-width="${strokeWidth}"`
+            }
 
             // Get the well-known name for the shape
             const wellKnownName = wellKnownNameNode ? wellKnownNameNode.textContent : '';
@@ -92,7 +100,7 @@ export default class LeafletSldLegend {
             const size = sizeNode ? sizeNode.textContent : '0';
 
             // Create an SVG representation of the shape (in this case, a circle)
-            svg += `<circle cx="50" cy="50" r="${size}" fill="${fillColor}" stroke="${strokeColor}" stroke-width="${strokeWidth}" />`;
+            svg += `<circle cx="50" cy="50" r="${size}" ${fillColorAttribute} ${strokeAttributes} />`;
         } else {
             // Check if there's a LineSymbolizer in the rule
             const lineSymbolizerNodes = ruleNode.getElementsByTagNameNS(namespaces.se, 'LineSymbolizer');


### PR DESCRIPTION
SLD supports circles for pointSymbolizers without stroke lines, but the plugin didn't support it previously. 
Also made a small change to add interactivity back (important for popups), but now it's possible to customize options in case someone wants interactivity false. This is a breaking change, but it's an important one, points should be interactive.